### PR TITLE
Expose goto func as Prop to renderSteps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,10 @@ class Loki extends Component {
     complete: false
   };
 
+  _goto(newStep) {
+    this.setState({ currentStep: newStep });
+  }
+
   _back(data) {
     this.props.onBack && this.props.onBack(data);
     this.setState({ currentStep: this.state.currentStep - 1 });
@@ -42,7 +46,8 @@ class Loki extends Component {
       cantBack: this.state.currentStep === 1,
       isInFinalStep: this.state.currentStep === this.props.steps.length,
       backHandler: this._back.bind(this),
-      nextHandler: this._next.bind(this)
+      nextHandler: this._next.bind(this),
+      gotoHandler: this._goto.bind(this)
     };
   }
 
@@ -62,7 +67,7 @@ class Loki extends Component {
         currentStep={this.state.currentStep}
         totalSteps={this.props.steps.length}
         step={{ ...step, index: index + 1 }}
-        goTo={newStep => this.setState({ currentStep: newStep })}
+        goTo={this._goto.bind(this  )}
         isLokiComplete={this.state.complete}
       />
     ));

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,6 @@ import LokiStep from "./LokiStep";
 import LokiStepContainer from "./LokiStepContainer";
 
 class Loki extends Component {
-  static defaultProps = {
-    backLabel: "Back",
-    nextLabel: "Next",
-    finishLabel: "Finish"
-  };
-
   state = {
     currentStep: 1,
     stepsDone: [],
@@ -157,8 +151,31 @@ class Loki extends Component {
 }
 
 Loki.propTypes = {
+  backLabel: PropTypes.string,
+  finishLabel: PropTypes.string,
+  nextLabel: PropTypes.string,
+  noActions: PropTypes.bool,
+  onBack: PropTypes.func,
+  onFinish: PropTypes.func.isRequired,
+  onNext: PropTypes.func,
+  renderActions: PropTypes.func,
+  renderComponents: PropTypes.func,
+  renderSteps: PropTypes.func,
   steps: PropTypes.array.isRequired,
-  onFinish: PropTypes.func.isRequired
 };
+
+Loki.defaultProps = {
+  backLabel: "Back",
+  nextLabel: "Next",
+  finishLabel: "Finish",
+  onBack: null,
+  onNext: null,
+  noActions: false,
+  onBack: null,
+  onNext: null,
+  renderActions: null,
+  renderComponents: null,
+  renderSteps: null,
+}
 
 export { Loki as default, LokiStepContainer, LokiStep };


### PR DESCRIPTION
It allows to call goto function when you customize renderSteps : 

```
<Loki
   onFinish={onFinish}
   noActions
   renderSteps={(props) => <CustomSteps steps={steps} {...props} />}
   steps={steps}
/>
```

```
const CustomSteps = ({ steps, currentStep, goto }) => {
       // now you can use goto
	const customSteps = steps.map((step, index) => {
		const isActive = currentStep === index + 1;
		const isNext = currentStep < index + 1;
		const handleClick = (e) => {
			e.preventDefault();
			if (isNext) return false;
			return goto(index + 1);
		};
		return (
			<li key={step.label} className={clsx('card-box', { current: isActive })}>
				<a href="#" onClick={handleClick} className={clsx({ disabled: isNext })} disabled={!!isNext}>
					<div className="label">{step.label}</div>
					<div className="step-indicator">{step.number}</div>
				</a>
			</li>
		);
	});

	return (
		<div className="horizontal">
			<ul className="steps-indicator">{customSteps}</ul>
		</div>
	);
};
```